### PR TITLE
Fix @page output

### DIFF
--- a/lib/src/css_printer.dart
+++ b/lib/src/css_printer.dart
@@ -107,16 +107,14 @@ class CssPrinter extends Visitor {
       emit(node._ident);
       emit(node.hasPseudoPage ? ':${node._pseudoPage}' : '');
     }
-    emit(' ');
 
     var declsMargin = node._declsMargin;
     var declsMarginLength = declsMargin.length;
+    emit(' {$_newLine');
     for (var i = 0; i < declsMarginLength; i++) {
-      if (i > 0) emit(_newLine);
-      emit('{$_newLine');
       declsMargin[i].visit(this);
-      emit('}');
     }
+    emit('}');
   }
 
   /** @charset "charset encoding" */

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.13.3
+version: 0.13.4
 author: Dart Team <misc@dartlang.org>
 description: A library for parsing CSS.
 homepage: https://github.com/dart-lang/csslib

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.13.2+2
+version: 0.13.3
 author: Dart Team <misc@dartlang.org>
 description: A library for parsing CSS.
 homepage: https://github.com/dart-lang/csslib

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -287,6 +287,7 @@ void testNewerCss() {
   width: 10px;
 }
 @page bar : left { @top-left { margin: 8px; } }
+@page { @top-left { margin: 8px; } width: 10px; }
 @charset "ISO-8859-1";
 @charset 'ASCII';''';
 
@@ -307,6 +308,12 @@ void testNewerCss() {
 @top-left {
   margin: 8px;
 }
+}
+@page {
+@top-left {
+  margin: 8px;
+}
+  width: 10px;
 }
 @charset "ISO-8859-1";
 @charset "ASCII";''';


### PR DESCRIPTION
CssPrinter now emits correct CSS when @page body includes both declarations and
page-margin boxes.