### PR TITLE
Exports `Message` from parser.dart.

### DIFF
--- a/example/call_parser.dart
+++ b/example/call_parser.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 
 import 'package:csslib/parser.dart' as css;
-import 'package:csslib/src/messages.dart';
 import 'package:csslib/visitor.dart';
 
 const _default = const css.PreprocessorOptions(
@@ -17,7 +16,7 @@ const _default = const css.PreprocessorOptions(
  * tests (by default) will ensure that the CSS is really valid.
  */
 StyleSheet parseCss(String cssInput,
-    {List<Message> errors, css.PreprocessorOptions opts}) {
+    {List<css.Message> errors, css.PreprocessorOptions opts}) {
   return css.parse(cssInput,
       errors: errors, options: opts == null ? _default : opts);
 }
@@ -28,7 +27,7 @@ String prettyPrint(StyleSheet ss) =>
     (emitCss..visitTree(ss, pretty: true)).toString();
 
 main() {
-  var errors = <Message>[];
+  var errors = <css.Message>[];
 
   // Parse a simple stylesheet.
   print('1. Good CSS, parsed CSS emitted:');

--- a/lib/css.dart
+++ b/lib/css.dart
@@ -10,9 +10,8 @@ import 'package:path/path.dart' as path;
 import 'package:source_span/source_span.dart';
 
 import 'parser.dart';
+import 'src/messages.dart' show Messages;
 import 'visitor.dart';
-import 'src/messages.dart';
-import 'src/options.dart';
 
 void main(List<String> arguments) {
   // TODO(jmesserly): fix this to return a proper exit code

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -8,10 +8,11 @@ import 'dart:math' as math;
 
 import 'package:source_span/source_span.dart';
 
-import "visitor.dart";
+import 'visitor.dart';
 import 'src/messages.dart';
 import 'src/options.dart';
 
+export 'src/messages.dart' show Message;
 export 'src/options.dart';
 
 part 'src/analyzer.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.13.2+2
+version: 0.13.3
 author: Dart Team <misc@dartlang.org>
 description: A library for parsing CSS.
 homepage: https://github.com/dart-lang/csslib


### PR DESCRIPTION
The parser API depended on `Message` which made it necessary to import
src/messages.dart to use parser.dart.