### PR TITLE
Handles CSS2.1 pseudo element syntax

### DIFF
--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -299,12 +299,17 @@ class PseudoClassSelector extends SimpleSelector {
 
 // ::pseudoElement
 class PseudoElementSelector extends SimpleSelector {
-  PseudoElementSelector(Identifier name, SourceSpan span) : super(name, span);
+  // If true, this is a CSS2.1 pseudo-element with only a single ':'.
+  final bool isLegacy;
+
+  PseudoElementSelector(Identifier name, SourceSpan span,
+      {this.isLegacy: false})
+      : super(name, span);
   visit(VisitorBase visitor) => visitor.visitPseudoElementSelector(this);
 
   PseudoElementSelector clone() => new PseudoElementSelector(_name, span);
 
-  String toString() => "::$name";
+  String toString() => "${isLegacy ? ':' : '::'}$name";
 }
 
 // :pseudoClassFunction(argument)


### PR DESCRIPTION
In CSS2.1, pseudo-elements were defined with a single ':' like pseudo-classes.
This change now handles this syntax and will properly parse them as pseudo-
elements instead of pseudo-classes.

Accepted pseudo-elements:
  :after
  :before
  :first-letter
  :first-line

To not break backwards compatibility with older browsers, this syntax is
preserved when emitting parsed styles.