### PR TITLE
Fixes parsing hex number when identifier follows

### DIFF
--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -2168,7 +2168,8 @@ class _Parser {
           if (_peekKind(TokenKind.INTEGER)) {
             String hexText1 = _peekToken.text;
             _next();
-            if (_peekIdentifier()) {
+            // Append identifier only if there's no delimiting whitespace.
+            if (_peekIdentifier() && _previousToken.end == _peekToken.start) {
               hexText = '$hexText1${identifier().name}';
             } else {
               hexText = hexText1;

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -566,6 +566,10 @@ div[href^='test'] {
 .test-background {
   background:  url(http://www.foo.com/bar.png);
 }
+
+.test-background-with-multiple-properties {
+  background: #000 url(http://www.foo.com/bar.png);
+}
 ''';
 
   final String generated = '@import "simple.css"; '
@@ -591,6 +595,9 @@ div[href^='test'] {
       '}\n'
       '.test-background {\n'
       '  background: url("http://www.foo.com/bar.png");\n'
+      '}\n'
+      '.test-background-with-multiple-properties {\n'
+      '  background: #000 url("http://www.foo.com/bar.png");\n'
       '}';
   var stylesheet = parseCss(input, errors: errors);
 


### PR DESCRIPTION
If an identifier followed a hex number, it would be treated as part of the hex
number. For example, `#000 url(...)` would be parsed as `#000url` which would be
labeled as a bad hex value.

Now the parser correctly recognizes whitespace following a hex number to prevent
this issue.