### PR TITLE
Fixes parsing string with unicode-range sequences

### DIFF
--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -202,8 +202,13 @@ class Tokenizer extends TokenizerBase {
           } else {
             return _errorToken();
           }
-        } else if ((ch == UNICODE_U || ch == UNICODE_LOWER_U) &&
+        } else if (_inString &&
+            (ch == UNICODE_U || ch == UNICODE_LOWER_U) &&
             (_peekChar() == UNICODE_PLUS)) {
+          // `_inString` is misleading. We actually DON'T want to enter this
+          // block while tokenizing a string, but the parser sets this value to
+          // false while it IS consuming tokens within a string.
+          //
           // Unicode range: U+uNumber[-U+uNumber]
           //   uNumber = 0..10FFFF
           _nextChar(); // Skip +

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -16,6 +16,7 @@ void testSimpleTerms() {
 @ import url("test.css");
 .foo {
   background-color: #191919;
+  content: "u+0041";
   width: 10PX;
   height: 22mM !important;
   border-width: 20cm;
@@ -29,6 +30,7 @@ void testSimpleTerms() {
 @import "test.css";
 .foo {
   background-color: #191919;
+  content: "u+0041";
   width: 10px;
   height: 22mm !important;
   border-width: 20cm;


### PR DESCRIPTION
Strings with character sequences that resemble `unicode-range` property values,
`U+0-10FFFF`, would be missing the `U+` sequence in the parsed output. This is
because the tokenizer doesn't tokenize strings as their own tokens, and midway
through a string it was trying to emit a unicode range token. We now check to
see if we're currently parsing a string before interpreting `U+` as the
beginning of a unicode range.