### PR TITLE
Prevents exception for invalid dimension terms

### DIFF
--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -2476,7 +2476,7 @@ class _Parser {
         break;
     }
 
-    return processDimension(t, value, _makeSpan(start));
+    return t != null ? processDimension(t, value, _makeSpan(start)) : null;
   }
 
   /** Process all dimension units. */

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -69,6 +69,17 @@ void testSimpleTerms() {
   expect(stylesheet != null, true);
   expect(errors.isEmpty, true, reason: errors.toString());
   expect(prettyPrint(stylesheet), generated2);
+
+  // Regression test to ensure invalid percentages don't throw an exception and
+  // instead print a useful error message when not in checked mode.
+  var css = '''
+.foo {
+  width: Infinity%;
+}''';
+  stylesheet = parseCss(css, errors: errors..clear(), opts: simpleOptions);
+  expect(errors, isNotEmpty);
+  expect(errors.first.message, 'expected }, but found %');
+  expect(errors.first.span.text, '%');
 }
 
 /**


### PR DESCRIPTION
While running outside of checked mode, parsing an invalid term expression
followed by a known dimension unit like

    width: Infinity%;

caused the following exception to be thrown:

    The getter 'text' was called on null.
    Receiver: null

Instead the parser now discards the invalid term, likely resulting in a useful
error message indicating the source of failure such as

    error on ...: expected }, but found %
      width: Infinity%;
                     ^

Fixes dart-lang/tools#1152.