### PR TITLE
Fix a crash caused by `:host()` without an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Fixed a crashed caused by parsing `:host()` without an argument and added an
+  error message explaining that a selector argument is expected.
+
 ## 0.14.4+1
 
 * Set max SDK version to `<3.0.0`, and adjust other dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.14.5
+
 * Fixed a crashed caused by parsing `:host()` without an argument and added an
   error message explaining that a selector argument is expected.
 

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1379,12 +1379,15 @@ class _Parser {
   /// supports Selector Level 4 grammar:
   /// https://drafts.csswg.org/selectors-4/#typedef-compound-selector
   Selector processCompoundSelector() {
-    return processSelector()
-      ..simpleSelectorSequences.forEach((sequence) {
+    var selector = processSelector();
+    if (selector != null) {
+      for (var sequence in selector.simpleSelectorSequences) {
         if (!sequence.isCombinatorNone) {
           _error('compound selector can not contain combinator', sequence.span);
         }
-      });
+      }
+    }
+    return selector;
   }
 
   simpleSelectorSequence(bool forceCombinatorNone) {
@@ -1625,6 +1628,10 @@ class _Parser {
       } else if (!pseudoElement && (name == 'host' || name == 'host-context')) {
         _eat(TokenKind.LPAREN);
         var selector = processCompoundSelector();
+        if (selector == null) {
+          _errorExpected('a selector argument');
+          return null;
+        }
         _eat(TokenKind.RPAREN);
         var span = _makeSpan(start);
         return new PseudoClassFunctionSelector(pseudoName, selector, span);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.14.4+1
+version: 0.14.5
 
 description: A library for parsing CSS.
 author: Dart Team <misc@dartlang.org>

--- a/test/selector_test.dart
+++ b/test/selector_test.dart
@@ -82,6 +82,13 @@ void testSelectorFailures() {
       'found a number\n'
       '.foobar .1a-story .xyzzy\n'
       '        ^^');
+
+  selector(':host()', errors: errors..clear());
+  expect(
+      errors.first.toString(),
+      'error on line 1, column 7: expected a selector argument, but found )\n'
+      ':host()\n'
+      '      ^');
 }
 
 main() {


### PR DESCRIPTION
Parsing `:host()` without an argument now emits an error explaining that a
selector argument is expected, rather than crashing.