### PR TITLE
Update test expectations for source_span output

### DIFF
--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -268,8 +268,7 @@ void testBadUnicode() {
       '  ╷\n'
       '3 │   unicode-range: U+400-200;\n'
       '  │                    ^^^^^^^\n'
-      '  ╵'
-      );
+      '  ╵');
 
   final String input2 = '''
 @font-face {
@@ -286,8 +285,7 @@ void testBadUnicode() {
       '  ╷\n'
       '3 │   unicode-range: U+12FFFF;\n'
       '  │                    ^^^^^^\n'
-      '  ╵'
-      );
+      '  ╵');
 }
 
 void testBadNesting() {

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -23,8 +23,10 @@ void testUnsupportedFontWeights() {
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 24: Unknown property value bolder
-.foobar { font-weight: bolder; }
-                       ^^^^^^''');
+  ╷
+1 │ .foobar { font-weight: bolder; }
+  │                        ^^^^^^
+  ╵''');
   expect(stylesheet != null, true);
 
   expect(prettyPrint(stylesheet), r'''
@@ -40,8 +42,10 @@ error on line 1, column 24: Unknown property value bolder
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 24: Unknown property value lighter
-.foobar { font-weight: lighter; }
-                       ^^^^^^^''');
+  ╷
+1 │ .foobar { font-weight: lighter; }
+  │                        ^^^^^^^
+  ╵''');
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -56,8 +60,10 @@ error on line 1, column 24: Unknown property value lighter
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 24: Unknown property value inherit
-.foobar { font-weight: inherit; }
-                       ^^^^^^^''');
+  ╷
+1 │ .foobar { font-weight: inherit; }
+  │                        ^^^^^^^
+  ╵''');
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -79,8 +85,10 @@ void testUnsupportedLineHeights() {
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 24: Unexpected value for line-height
-.foobar { line-height: 120%; }
-                       ^^^''');
+  ╷
+1 │ .foobar { line-height: 120%; }
+  │                        ^^^
+  ╵''');
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -95,8 +103,10 @@ error on line 1, column 24: Unexpected value for line-height
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 24: Unexpected unit for line-height
-.foobar { line-height: 20cm; }
-                       ^^''');
+  ╷
+1 │ .foobar { line-height: 20cm; }
+  │                        ^^
+  ╵''');
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -111,8 +121,10 @@ error on line 1, column 24: Unexpected unit for line-height
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 24: Unknown property value inherit
-.foobar { line-height: inherit; }
-                       ^^^^^^^''');
+  ╷
+1 │ .foobar { line-height: inherit; }
+  │                        ^^^^^^^
+  ╵''');
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -131,8 +143,10 @@ void testBadSelectors() {
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 1: Not a valid ID selector expected #id
-# foo { color: #ff00ff; }
-^''');
+  ╷
+1 │ # foo { color: #ff00ff; }
+  │ ^
+  ╵''');
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
 # foo {
@@ -146,8 +160,10 @@ error on line 1, column 1: Not a valid ID selector expected #id
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 1: Not a valid class selector expected .className
-. foo { color: #ff00ff; }
-^''');
+  ╷
+1 │ . foo { color: #ff00ff; }
+  │ ^
+  ╵''');
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
 . foo {
@@ -166,8 +182,10 @@ void testBadHexValues() {
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 18: Bad hex number
-.foobar { color: #AH787; }
-                 ^^^^^^''');
+  ╷
+1 │ .foobar { color: #AH787; }
+  │                  ^^^^^^
+  ╵''');
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -181,8 +199,10 @@ error on line 1, column 18: Bad hex number
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 18: Unknown property value redder
-.foobar { color: redder; }
-                 ^^^^^^''');
+  ╷
+1 │ .foobar { color: redder; }
+  │                  ^^^^^^
+  ╵''');
 
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
@@ -197,8 +217,10 @@ error on line 1, column 18: Unknown property value redder
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 18: Expected hex number
-.foobar { color: # ffffff; }
-                 ^''');
+  ╷
+1 │ .foobar { color: # ffffff; }
+  │                  ^
+  ╵''');
 
   expect(stylesheet != null, true);
   expect(prettyPrint(stylesheet), r'''
@@ -213,8 +235,10 @@ error on line 1, column 18: Expected hex number
   expect(errors.isEmpty, false);
   expect(errors[0].toString(), r'''
 error on line 1, column 18: Expected hex number
-.foobar { color: # 123fff; }
-                 ^''');
+  ╷
+1 │ .foobar { color: # 123fff; }
+  │                  ^
+  ╵''');
 
   expect(stylesheet != null, true);
 
@@ -241,8 +265,11 @@ void testBadUnicode() {
       errors[0].toString(),
       'error on line 3, column 20: unicode first range can not be greater than '
       'last\n'
-      '  unicode-range: U+400-200;\n'
-      '                   ^^^^^^^');
+      '  ╷\n'
+      '3 │   unicode-range: U+400-200;\n'
+      '  │                    ^^^^^^^\n'
+      '  ╵'
+      );
 
   final String input2 = '''
 @font-face {
@@ -256,8 +283,11 @@ void testBadUnicode() {
   expect(
       errors[0].toString(),
       'error on line 3, column 20: unicode range must be less than 10FFFF\n'
-      '  unicode-range: U+12FFFF;\n'
-      '                   ^^^^^^');
+      '  ╷\n'
+      '3 │   unicode-range: U+12FFFF;\n'
+      '  │                    ^^^^^^\n'
+      '  ╵'
+      );
 }
 
 void testBadNesting() {

--- a/test/selector_test.dart
+++ b/test/selector_test.dart
@@ -80,15 +80,21 @@ void testSelectorFailures() {
       errors[0].toString(),
       'error on line 1, column 9: name must start with a alpha character, but '
       'found a number\n'
-      '.foobar .1a-story .xyzzy\n'
-      '        ^^');
+      '  ╷\n'
+      '1 │ .foobar .1a-story .xyzzy\n'
+      '  │         ^^\n'
+      '  ╵'
+      );
 
   selector(':host()', errors: errors..clear());
   expect(
       errors.first.toString(),
       'error on line 1, column 7: expected a selector argument, but found )\n'
-      ':host()\n'
-      '      ^');
+      '  ╷\n'
+      '1 │ :host()\n'
+      '  │       ^\n'
+      '  ╵'
+      );
 }
 
 main() {

--- a/test/selector_test.dart
+++ b/test/selector_test.dart
@@ -83,8 +83,7 @@ void testSelectorFailures() {
       '  ╷\n'
       '1 │ .foobar .1a-story .xyzzy\n'
       '  │         ^^\n'
-      '  ╵'
-      );
+      '  ╵');
 
   selector(':host()', errors: errors..clear());
   expect(
@@ -93,8 +92,7 @@ void testSelectorFailures() {
       '  ╷\n'
       '1 │ :host()\n'
       '  │       ^\n'
-      '  ╵'
-      );
+      '  ╵');
 }
 
 main() {

--- a/test/var_test.dart
+++ b/test/var_test.dart
@@ -401,26 +401,40 @@ void undefinedVars() {
 
   var errorStrings = [
     'error on line 5, column 14: Variable is not defined.\n'
-        '  var-a: var(b);\n'
-        '             ^^',
+        '  ╷\n'
+        '5 │   var-a: var(b);\n'
+        '  │              ^^\n'
+        '  ╵',
     'error on line 6, column 14: Variable is not defined.\n'
-        '  var-b: var(c);\n'
-        '             ^^',
+        '  ╷\n'
+        '6 │   var-b: var(c);\n'
+        '  │              ^^\n'
+        '  ╵',
     'error on line 9, column 16: Variable is not defined.\n'
-        '  var-one: var(two);\n'
-        '               ^^^^',
+        '  ╷\n'
+        '9 │   var-one: var(two);\n'
+        '  │                ^^^^\n'
+        '  ╵',
     'error on line 12, column 17: Variable is not defined.\n'
-        '  var-four: var(five);\n'
-        '                ^^^^^',
+        '   ╷\n'
+        '12 │   var-four: var(five);\n'
+        '   │                 ^^^^^\n'
+        '   ╵',
     'error on line 13, column 17: Variable is not defined.\n'
-        '  var-five: var(six);\n'
-        '                ^^^^',
+        '   ╷\n'
+        '13 │   var-five: var(six);\n'
+        '   │                 ^^^^\n'
+        '   ╵',
     'error on line 16, column 18: Variable is not defined.\n'
-        '  var-def-1: var(def-2);\n'
-        '                 ^^^^^^',
+        '   ╷\n'
+        '16 │   var-def-1: var(def-2);\n'
+        '   │                  ^^^^^^\n'
+        '   ╵',
     'error on line 17, column 18: Variable is not defined.\n'
-        '  var-def-2: var(def-3);\n'
-        '                 ^^^^^^',
+        '   ╷\n'
+        '17 │   var-def-2: var(def-3);\n'
+        '   │                  ^^^^^^\n'
+        '   ╵',
   ];
 
   var generated = r'''


### PR DESCRIPTION
Version `1.5.0` of `source_span` changed the output format. Update the
tests which hardcoded the expected output to the new format.