### PR TITLE
 Remove support for shadow-piercing combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.16.0
+
+- Removed support for the shadow-piercing comibnators `/deep/` and `>>>`. These
+  were dropped from the Shadow DOM specification.
+
 ## 0.15.0
 
 - **BREAKING**

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -225,6 +225,8 @@ class _Parser {
       var selector = processSelector();
       if (selector != null) {
         productions.add(selector);
+      } else {
+        break; // Prevent infinite loop if we can't parse something.
       }
     }
 

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1374,29 +1374,12 @@ class _Parser {
         combinatorType = TokenKind.COMBINATOR_PLUS;
         break;
       case TokenKind.GREATER:
-        // Parse > or >>>
         _eat(TokenKind.GREATER);
-        if (_maybeEat(TokenKind.GREATER)) {
-          _eat(TokenKind.GREATER);
-          combinatorType = TokenKind.COMBINATOR_SHADOW_PIERCING_DESCENDANT;
-        } else {
-          combinatorType = TokenKind.COMBINATOR_GREATER;
-        }
+        combinatorType = TokenKind.COMBINATOR_GREATER;
         break;
       case TokenKind.TILDE:
         _eat(TokenKind.TILDE);
         combinatorType = TokenKind.COMBINATOR_TILDE;
-        break;
-      case TokenKind.SLASH:
-        // Parse /deep/
-        _eat(TokenKind.SLASH);
-        var ate = _maybeEat(TokenKind.IDENTIFIER);
-        var tok = ate ? _previousToken : _peekToken;
-        if (!(ate && tok.text == 'deep')) {
-          _error('expected deep, but found ${tok.text}', tok.span);
-        }
-        _eat(TokenKind.SLASH);
-        combinatorType = TokenKind.COMBINATOR_DEEP;
         break;
       case TokenKind.AMPERSAND:
         _eat(TokenKind.AMPERSAND);

--- a/lib/src/token_kind.dart
+++ b/lib/src/token_kind.dart
@@ -100,10 +100,8 @@ class TokenKind {
   static const int COMBINATOR_PLUS = 515; // + combinator
   static const int COMBINATOR_GREATER = 516; // > combinator
   static const int COMBINATOR_TILDE = 517; // ~ combinator
-  static const int COMBINATOR_SHADOW_PIERCING_DESCENDANT = 518; // >>>
-  static const int COMBINATOR_DEEP = 519; // /deep/ (aliases >>>)
 
-  static const int UNARY_OP_NONE = 520; // No unary operator present.
+  static const int UNARY_OP_NONE = 518; // No unary operator present.
 
   // Attribute match types:
   static const int INCLUDES = 530; // '~='

--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -120,16 +120,9 @@ class SimpleSelectorSequence extends TreeNode {
   bool get isCombinatorTilde => combinator == TokenKind.COMBINATOR_TILDE;
   bool get isCombinatorDescendant =>
       combinator == TokenKind.COMBINATOR_DESCENDANT;
-  bool get isCombinatorDeep => combinator == TokenKind.COMBINATOR_DEEP;
-  bool get isCombinatorShadowPiercingDescendant =>
-      combinator == TokenKind.COMBINATOR_SHADOW_PIERCING_DESCENDANT;
 
   String get _combinatorToString {
     switch (combinator) {
-      case TokenKind.COMBINATOR_SHADOW_PIERCING_DESCENDANT:
-        return ' >>> ';
-      case TokenKind.COMBINATOR_DEEP:
-        return ' /deep/ ';
       case TokenKind.COMBINATOR_DESCENDANT:
         return ' ';
       case TokenKind.COMBINATOR_GREATER:

--- a/lib/src/tree_printer.dart
+++ b/lib/src/tree_printer.dart
@@ -320,10 +320,6 @@ class _TreePrinter extends Visitor {
       output.writeValue('combinator', ">");
     } else if (node.isCombinatorTilde) {
       output.writeValue('combinator', "~");
-    } else if (node.isCombinatorShadowPiercingDescendant) {
-      output.writeValue('combinator', '>>>');
-    } else if (node.isCombinatorDeep) {
-      output.writeValue('combinator', '/deep/');
     } else {
       output.writeValue('combinator', "ERROR UNKNOWN");
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.15.1-dev
+version: 0.16.0
 
 description: A library for parsing CSS.
 author: Dart Team <misc@dartlang.org>

--- a/test/selector_test.dart
+++ b/test/selector_test.dart
@@ -58,14 +58,6 @@ void testSelectorSuccesses() {
   selectorAst = selector(':host-context(.foo)', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
   expect(compactOuptut(selectorAst), ':host-context(.foo)');
-
-  selectorAst = selector('.a /deep/ .b', errors: errors..clear());
-  expect(errors.isEmpty, true, reason: errors.toString());
-  expect(compactOuptut(selectorAst), '.a /deep/ .b');
-
-  selectorAst = selector('.x >>> .y', errors: errors..clear());
-  expect(errors.isEmpty, true, reason: errors.toString());
-  expect(compactOuptut(selectorAst), '.x >>> .y');
 }
 
 // TODO(terry): Move this failure case to a failure_test.dart when the analyzer


### PR DESCRIPTION
The parser no longer supports the `/deep/` and `>>>` combinators that
were historically used to pierce shadow boundaries. These combinators
have since been removed from the Shadow DOM specification.