### PR TITLE
Support parsing identifiers with escape codes in them

### DIFF
--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -20,7 +20,12 @@ class Identifier extends TreeNode {
   dynamic visit(VisitorBase visitor) => visitor.visitIdentifier(this);
 
   @override
-  String toString() => name;
+  String toString() {
+    // Try to use the identifier's original lexeme to preserve any escape codes
+    // as authored. The name, which may include escaped values, may no longer be
+    // a valid identifier.
+    return span?.text ?? name;
+  }
 }
 
 class Wildcard extends TreeNode {
@@ -274,7 +279,7 @@ class AttributeSelector extends SimpleSelector {
   String valueToString() {
     if (value != null) {
       if (value is Identifier) {
-        return value.name;
+        return value.toString();
       } else {
         return '"$value"';
       }

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -889,7 +889,7 @@ div {
 
   expect(stylesheet != null, true);
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect(compactOuptut(stylesheet), generated);
+  expect(compactOutput(stylesheet), generated);
 
   // Check namespace directive compactly emitted.
   final input2 = '@namespace a url(http://www.example.org/a);';
@@ -899,7 +899,7 @@ div {
 
   expect(stylesheet2 != null, true);
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect(compactOuptut(stylesheet2), generated2);
+  expect(compactOutput(stylesheet2), generated2);
 }
 
 void testNotSelectors() {

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -134,37 +134,27 @@ void testBadSelectors() {
 
   // Invalid id selector.
   var input = '# foo { color: #ff00ff; }';
-  var stylesheet = parseCss(input, errors: errors);
+  parseCss(input, errors: errors);
 
-  expect(errors.isEmpty, false);
+  expect(errors, isNotEmpty);
   expect(errors[0].toString(), r'''
 error on line 1, column 1: Not a valid ID selector expected #id
   ╷
 1 │ # foo { color: #ff00ff; }
   │ ^
   ╵''');
-  expect(stylesheet != null, true);
-  expect(prettyPrint(stylesheet), r'''
-# foo {
-  color: #f0f;
-}''');
 
   // Invalid class selector.
   input = '. foo { color: #ff00ff; }';
-  stylesheet = parseCss(input, errors: errors..clear());
+  parseCss(input, errors: errors..clear());
 
-  expect(errors.isEmpty, false);
+  expect(errors, isNotEmpty);
   expect(errors[0].toString(), r'''
 error on line 1, column 1: Not a valid class selector expected .className
   ╷
 1 │ . foo { color: #ff00ff; }
   │ ^
   ╵''');
-  expect(stylesheet != null, true);
-  expect(prettyPrint(stylesheet), r'''
-. foo {
-  color: #f0f;
-}''');
 }
 
 /// Test for bad hex values.

--- a/test/escape_codes_test.dart
+++ b/test/escape_codes_test.dart
@@ -1,0 +1,28 @@
+import 'package:csslib/parser.dart';
+import 'package:test/test.dart';
+
+import 'testing.dart';
+
+void main() {
+  final errors = <Message>[];
+
+  tearDown(() {
+    errors.clear();
+  });
+
+  group('handles escape codes', () {
+    group('in an identifier', () {
+      test('with trailing space', () {
+        final selectorAst = selector(r'.\35 00px', errors: errors);
+        expect(errors, isEmpty);
+        expect(compactOuptut(selectorAst), r'.\35 00px');
+      });
+
+      test('in an attribute selector value', () {
+        final selectorAst = selector(r'[elevation=\31]', errors: errors);
+        expect(errors, isEmpty);
+        expect(compactOuptut(selectorAst), r'[elevation=\31]');
+      });
+    });
+  });
+}

--- a/test/escape_codes_test.dart
+++ b/test/escape_codes_test.dart
@@ -15,13 +15,13 @@ void main() {
       test('with trailing space', () {
         final selectorAst = selector(r'.\35 00px', errors: errors);
         expect(errors, isEmpty);
-        expect(compactOuptut(selectorAst), r'.\35 00px');
+        expect(compactOutput(selectorAst), r'.\35 00px');
       });
 
       test('in an attribute selector value', () {
         final selectorAst = selector(r'[elevation=\31]', errors: errors);
         expect(errors, isEmpty);
-        expect(compactOuptut(selectorAst), r'[elevation=\31]');
+        expect(compactOutput(selectorAst), r'[elevation=\31]');
       });
     });
   });

--- a/test/selector_test.dart
+++ b/test/selector_test.dart
@@ -14,50 +14,50 @@ void testSelectorSuccesses() {
   var errors = <Message>[];
   var selectorAst = selector('#div .foo', errors: errors);
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect('#div .foo', compactOuptut(selectorAst));
+  expect('#div .foo', compactOutput(selectorAst));
 
   // Valid selectors for class names.
   selectorAst = selector('.foo', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect('.foo', compactOuptut(selectorAst));
+  expect('.foo', compactOutput(selectorAst));
 
   selectorAst = selector('.foobar .xyzzy', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect('.foobar .xyzzy', compactOuptut(selectorAst));
+  expect('.foobar .xyzzy', compactOutput(selectorAst));
 
   selectorAst = selector('.foobar .a-story .xyzzy', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect('.foobar .a-story .xyzzy', compactOuptut(selectorAst));
+  expect('.foobar .a-story .xyzzy', compactOutput(selectorAst));
 
   selectorAst =
       selector('.foobar .xyzzy .a-story .b-story', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect('.foobar .xyzzy .a-story .b-story', compactOuptut(selectorAst));
+  expect('.foobar .xyzzy .a-story .b-story', compactOutput(selectorAst));
 
   // Valid selectors for element IDs.
   selectorAst = selector('#id1', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect('#id1', compactOuptut(selectorAst));
+  expect('#id1', compactOutput(selectorAst));
 
   selectorAst = selector('#id-number-3', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect('#id-number-3', compactOuptut(selectorAst));
+  expect('#id-number-3', compactOutput(selectorAst));
 
   selectorAst = selector('#_privateId', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect('#_privateId', compactOuptut(selectorAst));
+  expect('#_privateId', compactOutput(selectorAst));
 
   selectorAst = selector(':host', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect(compactOuptut(selectorAst), ':host');
+  expect(compactOutput(selectorAst), ':host');
 
   selectorAst = selector(':host(.foo)', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect(compactOuptut(selectorAst), ':host(.foo)');
+  expect(compactOutput(selectorAst), ':host(.foo)');
 
   selectorAst = selector(':host-context(.foo)', errors: errors..clear());
   expect(errors.isEmpty, true, reason: errors.toString());
-  expect(compactOuptut(selectorAst), ':host-context(.foo)');
+  expect(compactOutput(selectorAst), ':host-context(.foo)');
 }
 
 // TODO(terry): Move this failure case to a failure_test.dart when the analyzer

--- a/test/testing.dart
+++ b/test/testing.dart
@@ -67,7 +67,7 @@ String prettyPrint(StyleSheet ss) {
 /// Helper function to emit compact (non-pretty printed) CSS for suite test
 /// comparsions.  Spaces, new lines, etc. are reduced for easier comparsions of
 /// expected suite test results.
-String compactOuptut(StyleSheet ss) {
+String compactOutput(StyleSheet ss) {
   walkTree(ss);
   return (_emitCss..visitTree(ss, pretty: false)).toString();
 }


### PR DESCRIPTION
The output of `CssPrinter` will now also retain escape codes in identifiers.
This ensures they remain valid identifiers, as the escaped values may not parse
as valid identifiers.

The parser will also no longer accept an ID or class selector with space between
the first token (`#` or `.` respectively) and the identifier. The parser will
now fail immediately on these selector errors instead of attempting to recover.
Recovering in a robust manner is difficult given that this parser immediately
attempts to parse at the selector granularity, rather than first parsing the
style sheet into rules as described [here][parse-rule].

[parse-rule]: https://www.w3.org/TR/css-syntax-3/#consume-a-qualified-rule

Fixes https://github.com/dart-lang/tools/issues/1157.