### PR TITLE
Refactor some private final fields with a getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.16.3-dev
+
 ## 0.16.2
 
 - Added support for escape codes in identifiers.

--- a/lib/src/css_printer.dart
+++ b/lib/src/css_printer.dart
@@ -303,9 +303,9 @@ class CssPrinter extends Visitor {
   @override
   void visitRuleSet(RuleSet node) {
     emit('$_newLine');
-    node._selectorGroup.visit(this);
+    node.selectorGroup.visit(this);
     emit('$_sp{$_newLine');
-    node._declarationGroup.visit(this);
+    node.declarationGroup.visit(this);
     emit('}');
   }
 
@@ -340,7 +340,7 @@ class CssPrinter extends Visitor {
   @override
   void visitDeclaration(Declaration node) {
     emit('${node.property}:$_sp');
-    node._expression.visit(this);
+    node.expression.visit(this);
     if (node.important) {
       emit('$_sp!important');
     }
@@ -349,7 +349,7 @@ class CssPrinter extends Visitor {
   @override
   void visitVarDefinition(VarDefinition node) {
     emit('var-${node.definedName}: ');
-    node._expression.visit(this);
+    node.expression.visit(this);
   }
 
   @override

--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -356,18 +356,17 @@ class PseudoElementSelector extends SimpleSelector {
 
 // :pseudoClassFunction(argument)
 class PseudoClassFunctionSelector extends PseudoClassSelector {
-  final TreeNode _argument; // Selector, SelectorExpression
+  final TreeNode argument; // Selector, SelectorExpression
 
-  PseudoClassFunctionSelector(Identifier name, this._argument, SourceSpan span)
+  PseudoClassFunctionSelector(Identifier name, this.argument, SourceSpan span)
       : super(name, span);
 
   @override
   PseudoClassFunctionSelector clone() =>
-      PseudoClassFunctionSelector(_name, _argument, span);
+      PseudoClassFunctionSelector(_name, argument, span);
 
-  TreeNode get argument => _argument;
-  Selector get selector => _argument as Selector;
-  SelectorExpression get expression => _argument as SelectorExpression;
+  Selector get selector => argument as Selector;
+  SelectorExpression get expression => argument as SelectorExpression;
 
   @override
   dynamic visit(VisitorBase visitor) =>
@@ -461,19 +460,16 @@ class TopLevelProduction extends TreeNode {
 }
 
 class RuleSet extends TopLevelProduction {
-  final SelectorGroup _selectorGroup;
-  final DeclarationGroup _declarationGroup;
+  final SelectorGroup selectorGroup;
+  final DeclarationGroup declarationGroup;
 
-  RuleSet(this._selectorGroup, this._declarationGroup, SourceSpan span)
+  RuleSet(this.selectorGroup, this.declarationGroup, SourceSpan span)
       : super(span);
-
-  SelectorGroup get selectorGroup => _selectorGroup;
-  DeclarationGroup get declarationGroup => _declarationGroup;
 
   @override
   RuleSet clone() {
-    var cloneSelectorGroup = _selectorGroup.clone();
-    var cloneDeclarationGroup = _declarationGroup.clone();
+    var cloneSelectorGroup = selectorGroup.clone();
+    var cloneDeclarationGroup = declarationGroup.clone();
     return RuleSet(cloneSelectorGroup, cloneDeclarationGroup, span);
   }
 
@@ -1013,7 +1009,7 @@ class ContentDirective extends Directive {
 
 class Declaration extends TreeNode {
   final Identifier _property;
-  final Expression _expression;
+  final Expression expression;
 
   /// Style exposed to Dart.
   DartStyleExpression dartStyle;
@@ -1028,19 +1024,18 @@ class Declaration extends TreeNode {
   ///   since an ident can start with underscore (e.g., `_background: red;`)
   final bool isIE7;
 
-  Declaration(this._property, this._expression, this.dartStyle, SourceSpan span,
+  Declaration(this._property, this.expression, this.dartStyle, SourceSpan span,
       {this.important = false, bool ie7 = false})
       : isIE7 = ie7,
         super(span);
 
   String get property => isIE7 ? '*${_property.name}' : _property.name;
-  Expression get expression => _expression;
 
   bool get hasDartStyle => dartStyle != null;
 
   @override
   Declaration clone() =>
-      Declaration(_property.clone(), _expression.clone(), dartStyle, span,
+      Declaration(_property.clone(), expression.clone(), dartStyle, span,
           important: important);
 
   @override

--- a/lib/src/tree_printer.dart
+++ b/lib/src/tree_printer.dart
@@ -310,7 +310,7 @@ class _TreePrinter extends Visitor {
     if (node.isIE7) output.write('IE7 property');
     output.write('property');
     super.visitDeclaration(node);
-    output.writeNode('expression', node._expression);
+    output.writeNode('expression', node.expression);
     if (node.important) {
       output.writeValue('!important', 'true');
     }
@@ -323,7 +323,7 @@ class _TreePrinter extends Visitor {
     output.depth++;
     output.write('defintion');
     super.visitVarDefinition(node);
-    output.writeNode('expression', node._expression);
+    output.writeNode('expression', node.expression);
     output.depth--;
   }
 

--- a/lib/visitor.dart
+++ b/lib/visitor.dart
@@ -294,8 +294,8 @@ class Visitor implements VisitorBase {
 
   @override
   dynamic visitRuleSet(RuleSet node) {
-    visitSelectorGroup(node._selectorGroup);
-    visitDeclarationGroup(node._declarationGroup);
+    visitSelectorGroup(node.selectorGroup);
+    visitDeclarationGroup(node.declarationGroup);
   }
 
   @override
@@ -309,13 +309,13 @@ class Visitor implements VisitorBase {
   @override
   dynamic visitDeclaration(Declaration node) {
     visitIdentifier(node._property);
-    if (node._expression != null) node._expression.visit(this);
+    if (node.expression != null) node.expression.visit(this);
   }
 
   @override
   dynamic visitVarDefinition(VarDefinition node) {
     visitIdentifier(node._property);
-    if (node._expression != null) node._expression.visit(this);
+    if (node.expression != null) node.expression.visit(this);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.16.2
+version: 0.16.3-dev
 
 description: A library for parsing CSS.
 homepage: https://github.com/dart-lang/csslib


### PR DESCRIPTION
When a field is `final` it is not necessary to make it private with a
forwarding getter.