### PR TITLE
Correct a misused putIfAbsent call

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -716,11 +716,8 @@ class DeclarationIncludes extends Visitor {
   bool _allIncludes(rulesets) =>
       rulesets.every((rule) => rule is IncludeDirective || rule is NoOp);
 
-  CallMixin _createCallDeclMixin(MixinDefinition mixinDef) {
-    callMap.putIfAbsent(mixinDef.name,
-        () => callMap[mixinDef.name] = CallMixin(mixinDef, varDefs));
-    return callMap[mixinDef.name];
-  }
+  CallMixin _createCallDeclMixin(MixinDefinition mixinDef) =>
+      callMap[mixinDef.name] ??= CallMixin(mixinDef, varDefs);
 
   @override
   void visitStyleSheet(StyleSheet ss) {


### PR DESCRIPTION
There is no need to assign within the callback for a `putIfAbsent`
default. Refactor to the most idiomatic version today which is to use
`??=` (since we don't ever assign a null value so we don't care about
the distinction between a missing key and a key assigned to null) and
return the value directly rather than putting it in the Map and then
pulling it back out.