### PR TITLE
Fix cast of nullable argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dart:
 
 dart_task:
   - test: --platform vm,chrome
+  - script: pub run --enable-experiment=non-nullable test --platform vm,chrome
 
 matrix:
   include:

--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -1583,7 +1583,7 @@ class FontExpression extends DartStyleExpression {
       String? variant,
       LineHeight? lineHeight})
       : font = Font(
-            size: size is LengthTerm ? size.value : size as num,
+            size: (size is LengthTerm ? size.value : size) as num?,
             family: family,
             weight: weight,
             style: style,


### PR DESCRIPTION
The `as num` cast existed before the migration, but in the wrong place
so the overall expression was still `dynamic`. Implicit casts from
`dynamic` are still allowed, so it wasn't flagged that the cast was in
the wrong place - disabling implicit casts from dynamic makes it more
obvious that there is a problem, but doesn't fix the entire issue.

In addition to the cast being in the wrong place, it also was to the
wrong type. Casting to `num` instead of `num?` does not surface any
warnings because it's valid to pass the `num` to an argument wanting
`num?`.

This was not surfaced originally due to a bug in the VM which causes the
opt-in state of a package in the experiment allow list to _not_ control
the soundness when executing. Add explicit opt in test runs for now.
https://github.com/dart-lang/sdk/issues/43243