### PR TITLE
Remove unnecessary cast.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - `Font.merge` and `BoxEdge.merge` are now static methods instead of factory
   constructors.
 - Add a type on the `identList` argument to `TokenKind.matchList`.
+- Remove workaround for https://github.com/dart-lang/sdk/issues/43136, which is
+  now fixed.
 
 ## 0.16.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: A library for parsing CSS.
 homepage: https://github.com/dart-lang/csslib
 
 environment:
-  sdk: '>=2.10.0-2.0.dev <2.10.0'
+  sdk: '>=2.11.0-0.0 <2.10.0'
 
 dependencies:
   source_span: ^1.8.0-nullsafety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: A library for parsing CSS.
 homepage: https://github.com/dart-lang/csslib
 
 environment:
-  sdk: '>=2.11.0-0.0 <2.10.0'
+  sdk: '>=2.11.0-0.0 <2.11.0'
 
 dependencies:
   source_span: ^1.8.0-nullsafety

--- a/test/samples_test.dart
+++ b/test/samples_test.dart
@@ -27,7 +27,7 @@ void main() {
   final cssDir = Directory.fromUri(libraryUri.resolve('examples'));
   for (var element in cssDir.listSync()) {
     if (element is File && element.uri.pathSegments.last.endsWith('.css')) {
-      test(element.uri.pathSegments.last, () => testCSSFile(element as File));
+      test(element.uri.pathSegments.last, () => testCSSFile(element));
     }
   }
 }


### PR DESCRIPTION
This cast was working around
https://github.com/dart-lang/sdk/issues/43136.  Now that it is fixed,
the cast is no longer needed.