### PR TITLE
Add a psuedo compound selector global-context

### DIFF
--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1550,7 +1550,10 @@ class _Parser {
 
         _eat(TokenKind.RPAREN);
         return NegationSelector(negArg, _makeSpan(start));
-      } else if (!pseudoElement && (name == 'host' || name == 'host-context')) {
+      } else if (!pseudoElement &&
+          (name == 'host' ||
+              name == 'host-context' ||
+              name == 'global-context')) {
         _eat(TokenKind.LPAREN);
         var selector = processCompoundSelector();
         if (selector == null) {


### PR DESCRIPTION
Add global-context to process it's compound selector. This will be used in the angular.dart framework to handle another encapsulation scenario.