### PR TITLE
Add -acx-global-context

### DIFF
--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1553,7 +1553,8 @@ class _Parser {
       } else if (!pseudoElement &&
           (name == 'host' ||
               name == 'host-context' ||
-              name == 'global-context')) {
+              name == 'global-context' ||
+              name == '-acx-global-context')) {
         _eat(TokenKind.LPAREN);
         var selector = processCompoundSelector();
         if (selector == null) {


### PR DESCRIPTION
Add -acx-global-context so that we can rename the usages of global-context to work better in the Sass system.