### PR TITLE
Fix failing tests, fix upper case in media directive expressions

### DIFF
--- a/lib/src/css_printer.dart
+++ b/lib/src/css_printer.dart
@@ -55,7 +55,7 @@ class CssPrinter extends Visitor {
 
   @override
   void visitMediaExpression(MediaExpression node) {
-    emit(node.andOperator ? ' AND ' : ' ');
+    emit(node.andOperator ? ' and ' : ' ');
     emit('(${node.mediaFeature}');
     if (node.exprs.expressions.isNotEmpty) {
       emit(':');

--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -716,8 +716,7 @@ class MediaQuery extends TreeNode {
 
   bool get hasUnary => _mediaUnary != -1;
   String get unary =>
-      TokenKind.idToValue(TokenKind.MEDIA_OPERATORS, _mediaUnary)!
-          .toUpperCase();
+      TokenKind.idToValue(TokenKind.MEDIA_OPERATORS, _mediaUnary)!;
 
   @override
   SourceSpan get span => super.span!;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.17.1
+version: 0.17.2
 
 description: A library for parsing and analyzing CSS (Cascading Style Sheets)
 repository: https://github.com/dart-lang/csslib

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -348,7 +348,7 @@ void testMediaQueries() {
   }
 }''';
   var generated = '''
-@media screen AND (-webkit-min-device-pixel-ratio:0) {
+@media screen and (-webkit-min-device-pixel-ratio:0) {
 .todo-item .toggle {
   background: none;
 }
@@ -381,7 +381,7 @@ void testMediaQueries() {
     }
   }''';
   generated =
-      '''@media handheld AND (min-width:20em), screen AND (min-width:20em) {
+      '''@media handheld and (min-width:20em), screen and (min-width:20em) {
 #id {
   color: #f00;
 }
@@ -389,12 +389,12 @@ void testMediaQueries() {
   height: 20px;
 }
 }
-@media print AND (min-resolution:300dpi) {
+@media print and (min-resolution:300dpi) {
 #anotherId {
   color: #fff;
 }
 }
-@media print AND (min-resolution:280dpcm) {
+@media print and (min-resolution:280dpcm) {
 #finalId {
   color: #aaa;
 }
@@ -415,8 +415,8 @@ void testMediaQueries() {
         font-size: 10em;
       }
     }''';
-  generated = '@media ONLY screen AND (min-device-width:4000px) '
-      'AND (min-device-height:2000px), screen AND (another:100px) {\n'
+  generated = '@media only screen and (min-device-width:4000px) '
+      'and (min-device-height:2000px), screen and (another:100px) {\n'
       'html {\n  font-size: 10em;\n}\n}';
 
   stylesheet = parseCss(input, errors: errors..clear(), opts: simpleOptions);
@@ -431,8 +431,8 @@ void testMediaQueries() {
         font-size: 10em;
       }
     }''';
-  generated = '@media screen, print AND (min-device-width:4000px) AND '
-      '(min-device-height:2000px), screen AND (another:100px) {\n'
+  generated = '@media screen, print and (min-device-width:4000px) and '
+      '(min-device-height:2000px), screen and (another:100px) {\n'
       'html {\n  font-size: 10em;\n}\n}';
 
   stylesheet = parseCss(input, errors: errors..clear(), opts: simpleOptions);
@@ -442,8 +442,8 @@ void testMediaQueries() {
 
   input = '''
 @import "test.css" ONLY screen, NOT print AND (min-device-width: 4000px);''';
-  generated = '@import "test.css" ONLY screen, '
-      'NOT print AND (min-device-width:4000px);';
+  generated = '@import "test.css" only screen, '
+      'not print and (min-device-width:4000px);';
 
   stylesheet = parseCss(input, errors: errors..clear(), opts: simpleOptions);
 
@@ -453,10 +453,10 @@ void testMediaQueries() {
   var css = '@media (min-device-width:400px) {\n}';
   expectCss(css, css);
 
-  css = '@media all AND (tranform-3d), (-webkit-transform-3d) {\n}';
+  css = '@media all and (transform-3d), (-webkit-transform-3d) {\n}';
   expectCss(css, css);
 
-  // Test that AND operator is required between media type and expressions.
+  // Test that 'and' operator is required between media type and expressions.
   css = '@media screen (min-device-width:400px';
   stylesheet = parseCss(css, errors: errors..clear(), opts: simpleOptions);
   expect(errors, isNotEmpty);
@@ -862,7 +862,7 @@ div {
       '@page{@top-left{color:red}}'
       '@page:first{}'
       '@page foo:first{}'
-      '@media screen AND (max-width:800px){div{font-size:24px}}'
+      '@media screen and (max-width:800px){div{font-size:24px}}'
       '@keyframes foo{0%{transform:scaleX(0)}}'
       'div{color:rgba(0,0,0,0.2)}';
 

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -19,12 +19,12 @@ void testUnsupportedFontWeights() {
   var stylesheet = parseCss(input, errors: errors);
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 24: Unknown property value bolder
-  ╷
-1 │ .foobar { font-weight: bolder; }
-  │                        ^^^^^^
-  ╵''');
+  ,
+1 | .foobar { font-weight: bolder; }
+  |                        ^^^^^^
+  \'''');
 
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -37,12 +37,12 @@ error on line 1, column 24: Unknown property value bolder
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 24: Unknown property value lighter
-  ╷
-1 │ .foobar { font-weight: lighter; }
-  │                        ^^^^^^^
-  ╵''');
+  ,
+1 | .foobar { font-weight: lighter; }
+  |                        ^^^^^^^
+  \'''');
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   font-weight: lighter;
@@ -54,12 +54,12 @@ error on line 1, column 24: Unknown property value lighter
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 24: Unknown property value inherit
-  ╷
-1 │ .foobar { font-weight: inherit; }
-  │                        ^^^^^^^
-  ╵''');
+  ,
+1 | .foobar { font-weight: inherit; }
+  |                        ^^^^^^^
+  \'''');
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   font-weight: inherit;
@@ -76,12 +76,12 @@ void testUnsupportedLineHeights() {
   var stylesheet = parseCss(input, errors: errors);
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 24: Unexpected value for line-height
-  ╷
-1 │ .foobar { line-height: 120%; }
-  │                        ^^^
-  ╵''');
+  ,
+1 | .foobar { line-height: 120%; }
+  |                        ^^^
+  \'''');
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   line-height: 120%;
@@ -93,12 +93,12 @@ error on line 1, column 24: Unexpected value for line-height
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 24: Unexpected unit for line-height
-  ╷
-1 │ .foobar { line-height: 20cm; }
-  │                        ^^
-  ╵''');
+  ,
+1 | .foobar { line-height: 20cm; }
+  |                        ^^
+  \'''');
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   line-height: 20cm;
@@ -110,12 +110,12 @@ error on line 1, column 24: Unexpected unit for line-height
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 24: Unknown property value inherit
-  ╷
-1 │ .foobar { line-height: inherit; }
-  │                        ^^^^^^^
-  ╵''');
+  ,
+1 | .foobar { line-height: inherit; }
+  |                        ^^^^^^^
+  \'''');
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   line-height: inherit;
@@ -131,24 +131,24 @@ void testBadSelectors() {
   parseCss(input, errors: errors);
 
   expect(errors, isNotEmpty);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 1: Not a valid ID selector expected #id
-  ╷
-1 │ # foo { color: #ff00ff; }
-  │ ^
-  ╵''');
+  ,
+1 | # foo { color: #ff00ff; }
+  | ^
+  \'''');
 
   // Invalid class selector.
   input = '. foo { color: #ff00ff; }';
   parseCss(input, errors: errors..clear());
 
   expect(errors, isNotEmpty);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 1: Not a valid class selector expected .className
-  ╷
-1 │ . foo { color: #ff00ff; }
-  │ ^
-  ╵''');
+  ,
+1 | . foo { color: #ff00ff; }
+  | ^
+  \'''');
 }
 
 /// Test for bad hex values.
@@ -160,12 +160,12 @@ void testBadHexValues() {
   var stylesheet = parseCss(input, errors: errors);
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 18: Bad hex number
-  ╷
-1 │ .foobar { color: #AH787; }
-  │                  ^^^^^^
-  ╵''');
+  ,
+1 | .foobar { color: #AH787; }
+  |                  ^^^^^^
+  \'''');
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   color: #AH787;
@@ -176,12 +176,12 @@ error on line 1, column 18: Bad hex number
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 18: Unknown property value redder
-  ╷
-1 │ .foobar { color: redder; }
-  │                  ^^^^^^
-  ╵''');
+  ,
+1 | .foobar { color: redder; }
+  |                  ^^^^^^
+  \'''');
 
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -193,12 +193,12 @@ error on line 1, column 18: Unknown property value redder
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 18: Expected hex number
-  ╷
-1 │ .foobar { color: # ffffff; }
-  │                  ^
-  ╵''');
+  ,
+1 | .foobar { color: # ffffff; }
+  |                  ^
+  \'''');
 
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -210,12 +210,12 @@ error on line 1, column 18: Expected hex number
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(errors[0].toString(), '''
 error on line 1, column 18: Expected hex number
-  ╷
-1 │ .foobar { color: # 123fff; }
-  │                  ^
-  ╵''');
+  ,
+1 | .foobar { color: # 123fff; }
+  |                  ^
+  \'''');
 
   // Formating is off with an extra space.  However, the entire value is bad
   // and isn't processed anyway.
@@ -240,10 +240,10 @@ void testBadUnicode() {
       errors[0].toString(),
       'error on line 3, column 20: unicode first range can not be greater than '
       'last\n'
-      '  ╷\n'
-      '3 │   unicode-range: U+400-200;\n'
-      '  │                    ^^^^^^^\n'
-      '  ╵');
+      '  ,\n'
+      '3 |   unicode-range: U+400-200;\n'
+      '  |                    ^^^^^^^\n'
+      '  \'');
 
   final input2 = '''
 @font-face {
@@ -257,10 +257,10 @@ void testBadUnicode() {
   expect(
       errors[0].toString(),
       'error on line 3, column 20: unicode range must be less than 10FFFF\n'
-      '  ╷\n'
-      '3 │   unicode-range: U+12FFFF;\n'
-      '  │                    ^^^^^^\n'
-      '  ╵');
+      '  ,\n'
+      '3 |   unicode-range: U+12FFFF;\n'
+      '  |                    ^^^^^^\n'
+      '  \'');
 }
 
 void testBadNesting() {

--- a/test/nested_test.dart
+++ b/test/nested_test.dart
@@ -353,7 +353,7 @@ void mediaNesting() {
   }
 }
 ''';
-  final generated = r'''@media screen AND (-webkit-min-device-pixel-ratio:0) {
+  final generated = r'''@media screen and (-webkit-min-device-pixel-ratio:0) {
 #toggle-all {
   image: url("test.jpb");
   color: #f00;

--- a/test/selector_test.dart
+++ b/test/selector_test.dart
@@ -71,19 +71,19 @@ void testSelectorFailures() {
       errors[0].toString(),
       'error on line 1, column 9: name must start with a alpha character, but '
       'found a number\n'
-      '  ╷\n'
-      '1 │ .foobar .1a-story .xyzzy\n'
-      '  │         ^^\n'
-      '  ╵');
+      '  ,\n'
+      '1 | .foobar .1a-story .xyzzy\n'
+      '  |         ^^\n'
+      '  \'');
 
   selector(':host()', errors: errors..clear());
   expect(
       errors.first.toString(),
       'error on line 1, column 7: expected a selector argument, but found )\n'
-      '  ╷\n'
-      '1 │ :host()\n'
-      '  │       ^\n'
-      '  ╵');
+      '  ,\n'
+      '1 | :host()\n'
+      '  |       ^\n'
+      '  \'');
 }
 
 void main() {

--- a/test/var_test.dart
+++ b/test/var_test.dart
@@ -404,40 +404,40 @@ void undefinedVars() {
 
   var errorStrings = [
     'error on line 5, column 14: Variable is not defined.\n'
-        '  ╷\n'
-        '5 │   var-a: var(b);\n'
-        '  │              ^^\n'
-        '  ╵',
+        '  ,\n'
+        '5 |   var-a: var(b);\n'
+        '  |              ^^\n'
+        '  \'',
     'error on line 6, column 14: Variable is not defined.\n'
-        '  ╷\n'
-        '6 │   var-b: var(c);\n'
-        '  │              ^^\n'
-        '  ╵',
+        '  ,\n'
+        '6 |   var-b: var(c);\n'
+        '  |              ^^\n'
+        '  \'',
     'error on line 9, column 16: Variable is not defined.\n'
-        '  ╷\n'
-        '9 │   var-one: var(two);\n'
-        '  │                ^^^^\n'
-        '  ╵',
+        '  ,\n'
+        '9 |   var-one: var(two);\n'
+        '  |                ^^^^\n'
+        '  \'',
     'error on line 12, column 17: Variable is not defined.\n'
-        '   ╷\n'
-        '12 │   var-four: var(five);\n'
-        '   │                 ^^^^^\n'
-        '   ╵',
+        '   ,\n'
+        '12 |   var-four: var(five);\n'
+        '   |                 ^^^^^\n'
+        '   \'',
     'error on line 13, column 17: Variable is not defined.\n'
-        '   ╷\n'
-        '13 │   var-five: var(six);\n'
-        '   │                 ^^^^\n'
-        '   ╵',
+        '   ,\n'
+        '13 |   var-five: var(six);\n'
+        '   |                 ^^^^\n'
+        '   \'',
     'error on line 16, column 18: Variable is not defined.\n'
-        '   ╷\n'
-        '16 │   var-def-1: var(def-2);\n'
-        '   │                  ^^^^^^\n'
-        '   ╵',
+        '   ,\n'
+        '16 |   var-def-1: var(def-2);\n'
+        '   |                  ^^^^^^\n'
+        '   \'',
     'error on line 17, column 18: Variable is not defined.\n'
-        '   ╷\n'
-        '17 │   var-def-2: var(def-3);\n'
-        '   │                  ^^^^^^\n'
-        '   ╵',
+        '   ,\n'
+        '17 |   var-def-2: var(def-3);\n'
+        '   |                  ^^^^^^\n'
+        '   \'',
   ];
 
   var generated = r'''


### PR DESCRIPTION
Hi,
I've been working on my CSS purging logic and the upper case `AND`, `ONLY` and `NOT` in `@media` directive expressions, produced by the `CssPrinter` have caused editors to throw endless warnings. It was also a bit painful to the eyes to see upper case in a mix with the standard lower case usage, so I finally gave up.

While running `dart test` with the updated case, there was also multiple test cases that were failing to complete.

My feeling is this shouldn't break anything major.