### PR TITLE
Fix upper cases in media expressions, fix test failures related to platform-dependent error output with glyphs, fix failure to comma-separate keyframes percentage list

### DIFF
--- a/lib/src/css_printer.dart
+++ b/lib/src/css_printer.dart
@@ -612,7 +612,7 @@ class CssPrinter extends Visitor {
     var expressions = node.expressions;
     var expressionsLength = expressions.length;
     for (var i = 0; i < expressionsLength; i++) {
-      // Add space seperator between terms without an operator.
+      // Add space separator between terms without an operator.
       // TODO(terry): Should have a BinaryExpression to solve this problem.
       var expression = expressions[i];
       if (i > 0 &&
@@ -623,6 +623,9 @@ class CssPrinter extends Visitor {
         // expressions and can't be collapsed.
         var previous = expressions[i - 1];
         if (previous is OperatorComma || previous is OperatorSlash) {
+          emit(_sp);
+        } else if (previous is PercentageTerm && expression is PercentageTerm) {
+          emit(',');
           emit(_sp);
         } else {
           emit(' ');

--- a/lib/src/css_printer.dart
+++ b/lib/src/css_printer.dart
@@ -55,7 +55,7 @@ class CssPrinter extends Visitor {
 
   @override
   void visitMediaExpression(MediaExpression node) {
-    emit(node.andOperator ? ' AND ' : ' ');
+    emit(node.andOperator ? ' and ' : ' ');
     emit('(${node.mediaFeature}');
     if (node.exprs.expressions.isNotEmpty) {
       emit(':');

--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -716,8 +716,7 @@ class MediaQuery extends TreeNode {
 
   bool get hasUnary => _mediaUnary != -1;
   String get unary =>
-      TokenKind.idToValue(TokenKind.MEDIA_OPERATORS, _mediaUnary)!
-          .toUpperCase();
+      TokenKind.idToValue(TokenKind.MEDIA_OPERATORS, _mediaUnary)!;
 
   @override
   SourceSpan get span => super.span!;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.17.3
+version: 0.17.2
 
 description: A library for parsing and analyzing CSS (Cascading Style Sheets)
 repository: https://github.com/dart-lang/csslib

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.17.2
+version: 0.17.3
 
 description: A library for parsing and analyzing CSS (Cascading Style Sheets)
 repository: https://github.com/dart-lang/csslib

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.17.1
+version: 0.17.2
 
 description: A library for parsing and analyzing CSS (Cascading Style Sheets)
 repository: https://github.com/dart-lang/csslib
@@ -13,4 +13,5 @@ dependencies:
 dev_dependencies:
   path: ^1.8.0
   pedantic: ^1.10.0
+  term_glyph: ^1.2.0
   test: ^1.16.0

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -348,7 +348,7 @@ void testMediaQueries() {
   }
 }''';
   var generated = '''
-@media screen AND (-webkit-min-device-pixel-ratio:0) {
+@media screen and (-webkit-min-device-pixel-ratio:0) {
 .todo-item .toggle {
   background: none;
 }
@@ -381,7 +381,7 @@ void testMediaQueries() {
     }
   }''';
   generated =
-      '''@media handheld AND (min-width:20em), screen AND (min-width:20em) {
+      '''@media handheld and (min-width:20em), screen and (min-width:20em) {
 #id {
   color: #f00;
 }
@@ -389,12 +389,12 @@ void testMediaQueries() {
   height: 20px;
 }
 }
-@media print AND (min-resolution:300dpi) {
+@media print and (min-resolution:300dpi) {
 #anotherId {
   color: #fff;
 }
 }
-@media print AND (min-resolution:280dpcm) {
+@media print and (min-resolution:280dpcm) {
 #finalId {
   color: #aaa;
 }
@@ -415,8 +415,8 @@ void testMediaQueries() {
         font-size: 10em;
       }
     }''';
-  generated = '@media ONLY screen AND (min-device-width:4000px) '
-      'AND (min-device-height:2000px), screen AND (another:100px) {\n'
+  generated = '@media only screen and (min-device-width:4000px) '
+      'and (min-device-height:2000px), screen and (another:100px) {\n'
       'html {\n  font-size: 10em;\n}\n}';
 
   stylesheet = parseCss(input, errors: errors..clear(), opts: simpleOptions);
@@ -431,8 +431,8 @@ void testMediaQueries() {
         font-size: 10em;
       }
     }''';
-  generated = '@media screen, print AND (min-device-width:4000px) AND '
-      '(min-device-height:2000px), screen AND (another:100px) {\n'
+  generated = '@media screen, print and (min-device-width:4000px) and '
+      '(min-device-height:2000px), screen and (another:100px) {\n'
       'html {\n  font-size: 10em;\n}\n}';
 
   stylesheet = parseCss(input, errors: errors..clear(), opts: simpleOptions);
@@ -442,8 +442,8 @@ void testMediaQueries() {
 
   input = '''
 @import "test.css" ONLY screen, NOT print AND (min-device-width: 4000px);''';
-  generated = '@import "test.css" ONLY screen, '
-      'NOT print AND (min-device-width:4000px);';
+  generated = '@import "test.css" only screen, '
+      'not print and (min-device-width:4000px);';
 
   stylesheet = parseCss(input, errors: errors..clear(), opts: simpleOptions);
 
@@ -453,10 +453,10 @@ void testMediaQueries() {
   var css = '@media (min-device-width:400px) {\n}';
   expectCss(css, css);
 
-  css = '@media all AND (tranform-3d), (-webkit-transform-3d) {\n}';
+  css = '@media all and (transform-3d), (-webkit-transform-3d) {\n}';
   expectCss(css, css);
 
-  // Test that AND operator is required between media type and expressions.
+  // Test that 'and' operator is required between media type and expressions.
   css = '@media screen (min-device-width:400px';
   stylesheet = parseCss(css, errors: errors..clear(), opts: simpleOptions);
   expect(errors, isNotEmpty);
@@ -862,7 +862,7 @@ div {
       '@page{@top-left{color:red}}'
       '@page:first{}'
       '@page foo:first{}'
-      '@media screen AND (max-width:800px){div{font-size:24px}}'
+      '@media screen and (max-width:800px){div{font-size:24px}}'
       '@keyframes foo{0%{transform:scaleX(0)}}'
       'div{color:rgba(0,0,0,0.2)}';
 

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -19,12 +19,15 @@ void testUnsupportedFontWeights() {
   var stylesheet = parseCss(input, errors: errors);
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 24: Unknown property value bolder
   ╷
 1 │ .foobar { font-weight: bolder; }
   │                        ^^^^^^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
 
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -37,12 +40,15 @@ error on line 1, column 24: Unknown property value bolder
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 24: Unknown property value lighter
   ╷
 1 │ .foobar { font-weight: lighter; }
   │                        ^^^^^^^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   font-weight: lighter;
@@ -54,12 +60,15 @@ error on line 1, column 24: Unknown property value lighter
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 24: Unknown property value inherit
   ╷
 1 │ .foobar { font-weight: inherit; }
   │                        ^^^^^^^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   font-weight: inherit;
@@ -76,12 +85,15 @@ void testUnsupportedLineHeights() {
   var stylesheet = parseCss(input, errors: errors);
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 24: Unexpected value for line-height
   ╷
 1 │ .foobar { line-height: 120%; }
   │                        ^^^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   line-height: 120%;
@@ -93,12 +105,15 @@ error on line 1, column 24: Unexpected value for line-height
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 24: Unexpected unit for line-height
   ╷
 1 │ .foobar { line-height: 20cm; }
   │                        ^^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   line-height: 20cm;
@@ -110,12 +125,15 @@ error on line 1, column 24: Unexpected unit for line-height
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 24: Unknown property value inherit
   ╷
 1 │ .foobar { line-height: inherit; }
   │                        ^^^^^^^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   line-height: inherit;
@@ -131,24 +149,30 @@ void testBadSelectors() {
   parseCss(input, errors: errors);
 
   expect(errors, isNotEmpty);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 1: Not a valid ID selector expected #id
   ╷
 1 │ # foo { color: #ff00ff; }
   │ ^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
 
   // Invalid class selector.
   input = '. foo { color: #ff00ff; }';
   parseCss(input, errors: errors..clear());
 
   expect(errors, isNotEmpty);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 1: Not a valid class selector expected .className
   ╷
 1 │ . foo { color: #ff00ff; }
   │ ^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
 }
 
 /// Test for bad hex values.
@@ -160,12 +184,15 @@ void testBadHexValues() {
   var stylesheet = parseCss(input, errors: errors);
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 18: Bad hex number
   ╷
 1 │ .foobar { color: #AH787; }
   │                  ^^^^^^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
   expect(prettyPrint(stylesheet), r'''
 .foobar {
   color: #AH787;
@@ -176,12 +203,15 @@ error on line 1, column 18: Bad hex number
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 18: Unknown property value redder
   ╷
 1 │ .foobar { color: redder; }
   │                  ^^^^^^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
 
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -193,12 +223,15 @@ error on line 1, column 18: Unknown property value redder
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 18: Expected hex number
   ╷
 1 │ .foobar { color: # ffffff; }
   │                  ^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
 
   expect(prettyPrint(stylesheet), r'''
 .foobar {
@@ -210,12 +243,15 @@ error on line 1, column 18: Expected hex number
   stylesheet = parseCss(input, errors: errors..clear());
 
   expect(errors.isEmpty, false);
-  expect(errors[0].toString(), r'''
+  expect(
+      errors[0].toString(),
+      r'''
 error on line 1, column 18: Expected hex number
   ╷
 1 │ .foobar { color: # 123fff; }
   │                  ^
-  ╵''');
+  ╵'''
+          .patchGlyphs());
 
   // Formating is off with an extra space.  However, the entire value is bad
   // and isn't processed anyway.
@@ -239,11 +275,12 @@ void testBadUnicode() {
   expect(
       errors[0].toString(),
       'error on line 3, column 20: unicode first range can not be greater than '
-      'last\n'
-      '  ╷\n'
-      '3 │   unicode-range: U+400-200;\n'
-      '  │                    ^^^^^^^\n'
-      '  ╵');
+              'last\n'
+              '  ╷\n'
+              '3 │   unicode-range: U+400-200;\n'
+              '  │                    ^^^^^^^\n'
+              '  ╵'
+          .patchGlyphs());
 
   final input2 = '''
 @font-face {
@@ -257,10 +294,11 @@ void testBadUnicode() {
   expect(
       errors[0].toString(),
       'error on line 3, column 20: unicode range must be less than 10FFFF\n'
-      '  ╷\n'
-      '3 │   unicode-range: U+12FFFF;\n'
-      '  │                    ^^^^^^\n'
-      '  ╵');
+              '  ╷\n'
+              '3 │   unicode-range: U+12FFFF;\n'
+              '  │                    ^^^^^^\n'
+              '  ╵'
+          .patchGlyphs());
 }
 
 void testBadNesting() {

--- a/test/keyframes_test.dart
+++ b/test/keyframes_test.dart
@@ -1,0 +1,141 @@
+library extend_test;
+
+import 'package:csslib/src/messages.dart';
+import 'package:test/test.dart';
+
+import 'testing.dart';
+
+void compileAndValidate(String input, String generated) {
+  var errors = <Message>[];
+  var stylesheet = compileCss(input, errors: errors, opts: options);
+  expect(errors.isEmpty, true, reason: errors.toString());
+  expect(prettyPrint(stylesheet), generated);
+}
+
+void singleKeyframesList() {
+  compileAndValidate(r'''
+@keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}''', r'''
+@keyframes ping {
+  75%, 100% {
+  transform: scale(2);
+  opacity: 0;
+  }
+}''');
+}
+
+void keyframesList() {
+  compileAndValidate(r'''
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+@keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+@-webkit-keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+@-webkit-keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+  50% {
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+  50% {
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+''', r'''
+@keyframes spin {
+  to {
+  transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes ping {
+  75%, 100% {
+  transform: scale(2);
+  opacity: 0;
+  }
+}
+@keyframes ping {
+  75%, 100% {
+  transform: scale(2);
+  opacity: 0;
+  }
+}
+@-webkit-keyframes pulse {
+  50% {
+  opacity: 0.5;
+  }
+}
+@keyframes pulse {
+  50% {
+  opacity: 0.5;
+  }
+}
+@-webkit-keyframes bounce {
+  0%, 100% {
+  transform: translateY(-25%);
+  -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+  50% {
+  transform: none;
+  -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+@keyframes bounce {
+  0%, 100% {
+  transform: translateY(-25%);
+  -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+  50% {
+  transform: none;
+  -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}''');
+}
+
+void main() {
+  test('Single Keyframes List', singleKeyframesList);
+  test('Keyframes List', keyframesList);
+}

--- a/test/nested_test.dart
+++ b/test/nested_test.dart
@@ -353,7 +353,7 @@ void mediaNesting() {
   }
 }
 ''';
-  final generated = r'''@media screen AND (-webkit-min-device-pixel-ratio:0) {
+  final generated = r'''@media screen and (-webkit-min-device-pixel-ratio:0) {
 #toggle-all {
   image: url("test.jpb");
   color: #f00;

--- a/test/selector_test.dart
+++ b/test/selector_test.dart
@@ -70,20 +70,22 @@ void testSelectorFailures() {
   expect(
       errors[0].toString(),
       'error on line 1, column 9: name must start with a alpha character, but '
-      'found a number\n'
-      '  ╷\n'
-      '1 │ .foobar .1a-story .xyzzy\n'
-      '  │         ^^\n'
-      '  ╵');
+              'found a number\n'
+              '  ╷\n'
+              '1 │ .foobar .1a-story .xyzzy\n'
+              '  │         ^^\n'
+              '  ╵'
+          .patchGlyphs());
 
   selector(':host()', errors: errors..clear());
   expect(
       errors.first.toString(),
       'error on line 1, column 7: expected a selector argument, but found )\n'
-      '  ╷\n'
-      '1 │ :host()\n'
-      '  │       ^\n'
-      '  ╵');
+              '  ╷\n'
+              '1 │ :host()\n'
+              '  │       ^\n'
+              '  ╵'
+          .patchGlyphs());
 }
 
 void main() {

--- a/test/testing.dart
+++ b/test/testing.dart
@@ -7,6 +7,7 @@ library testing;
 
 import 'package:csslib/parser.dart';
 import 'package:csslib/visitor.dart';
+import 'package:term_glyph/term_glyph.dart';
 
 export 'package:csslib/src/preprocessor_options.dart';
 
@@ -57,13 +58,13 @@ final _cssVisitor = Visitor();
 
 /// Pretty printer for CSS.
 String prettyPrint(StyleSheet ss) {
-  // Walk the tree testing basic Vistor class.
+  // Walk the tree testing basic Visitor class.
   walkTree(ss);
   return (_emitCss..visitTree(ss, pretty: true)).toString();
 }
 
 /// Helper function to emit compact (non-pretty printed) CSS for suite test
-/// comparsions.  Spaces, new lines, etc. are reduced for easier comparsions of
+/// comparisons.  Spaces, new lines, etc. are reduced for easier comparisons of
 /// expected suite test results.
 String compactOutput(StyleSheet ss) {
   walkTree(ss);
@@ -76,3 +77,15 @@ void walkTree(StyleSheet ss) {
 }
 
 String dumpTree(StyleSheet ss) => treeToDebugString(ss);
+
+/// StringRegionPatcher extends String to add a [patchGlyphs] method.
+extension StringRegionPatcher on String {
+  /// patchRegion replaces special characters describing spans that are used in
+  /// the literal error messages throughout the tests to avoid errors related to
+  /// absence of unicode glyphs depending on their runtime existence.
+  String patchGlyphs() {
+    return replaceAll('╷', glyphs.downEnd)
+        .replaceAll('│', glyphs.verticalLine)
+        .replaceAll('╵', glyphs.upEnd);
+  }
+}

--- a/test/var_test.dart
+++ b/test/var_test.dart
@@ -438,7 +438,7 @@ void undefinedVars() {
         '17 │   var-def-2: var(def-3);\n'
         '   │                  ^^^^^^\n'
         '   ╵',
-  ];
+  ].map((e) => e.patchGlyphs()).toList();
 
   var generated = r'''
 :root {


### PR DESCRIPTION
Attempt 2, taking into account that some platforms may have unicode glyphs to describe the source spans, and some may not.