### PR TITLE
Prepare to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-## 0.17.3-dev
-
-- Add commas between PercentageTerms in keyframe rules.
-
 ## 0.17.2
 
 - Fixed a crash caused by `min()`, `max()` and `clamp()` functions that contain
   mathematical expressions.
+- Add commas between PercentageTerms in keyframe rules.
 
 ## 0.17.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 0.17.3-dev
+version: 0.17.2
 
 description: A library for parsing and analyzing CSS (Cascading Style Sheets)
 repository: https://github.com/dart-lang/csslib


### PR DESCRIPTION
The `0.17.2` version was inadvertently not published so go back to that
version.