### PR TITLE
correct the logic in isPredefinedName

### DIFF
--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -135,7 +135,7 @@ String _inputAsString(Object input) {
     // Here's some info about CSS encodings:
     // http://www.w3.org/International/questions/qa-css-charset.en.php
     //
-    // As JMesserly suggests it will probably need a "preparser" html5lib
+    // As JMesserly suggests it will probably need a "pre-parser" html5lib
     // (encoding_parser.dart) that interprets the bytes as ASCII and scans for
     // @charset. But for now an "encoding" argument would work.  Often the
     // HTTP header will indicate the correct encoding.
@@ -240,7 +240,7 @@ class _Parser {
   }
 
   /// Guard to break out of parser when an unexpected end of file is found.
-  // TODO(jimhug): Failure to call this method can lead to inifinite parser
+  // TODO(jimhug): Failure to call this method can lead to infinite parser
   //   loops.  Consider embracing exceptions for more errors to reduce
   //   the danger here.
   bool isPrematureEndOfFile() {
@@ -1127,8 +1127,7 @@ class _Parser {
   ///       color: red;
   ///     }
   ///
-  /// Return [:null:] if no selector or [SelectorGroup] if a selector was
-  /// parsed.
+  /// Return `null` if no selector or [SelectorGroup] if a selector was parsed.
   SelectorGroup? _nestedSelector() {
     var oldMessages = messages;
     _createMessages();
@@ -1946,7 +1945,7 @@ class _Parser {
         //   100 - 900
         //   inherit
 
-        // TODO(terry): Only 'normal', 'bold', or values of 100-900 supoorted
+        // TODO(terry): Only 'normal', 'bold', or values of 100-900 supported
         //              need to handle bolder, lighter, and inherit.  See
         //              https://github.com/dart-lang/csslib/issues/1
         var expr = exprs.expressions[0];
@@ -2832,10 +2831,10 @@ class ExpressionsProcessor {
       // Order is font-size font-family
       fontSize ??= processFontSize();
       fontFamily ??= processFontFamily();
-      //TODO(terry): Handle font-weight, font-style, and font-variant. See
-      //               https://github.com/dart-lang/csslib/issues/3
-      //               https://github.com/dart-lang/csslib/issues/4
-      //               https://github.com/dart-lang/csslib/issues/5
+      // TODO(terry): Handle font-weight, font-style, and font-variant. See
+      //              https://github.com/dart-lang/csslib/issues/3
+      //              https://github.com/dart-lang/csslib/issues/4
+      //              https://github.com/dart-lang/csslib/issues/5
     }
 
     return FontExpression(_exprs.span,

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -41,7 +41,7 @@ class Analyzer {
       MixinsAndIncludes.remove(styleSheet);
     }
 
-    // Expand any nested selectors using selector desendant combinator to
+    // Expand any nested selectors using selector descendant combinator to
     // signal CSS inheritance notation.
     for (var styleSheet in _styleSheets) {
       ExpandNestedSelectors()
@@ -165,14 +165,14 @@ class Analyzer {
 ///                       Declaration (property = color, expression = red)
 ///
 /// Nested rules is a terse mechanism to describe CSS inheritance.  The analyzer
-/// will flatten and expand the nested rules to it's flatten strucure.  Using
+/// will flatten and expand the nested rules to it's flatten structure.  Using
 /// the all parent [RuleSets] (selector expressions) and applying each nested
 /// [RuleSet] to the list of [Selectors] in a [SelectorGroup].
 ///
 /// Then result is a style sheet where all nested rules have been flatten and
 /// expanded.
 class ExpandNestedSelectors extends Visitor {
-  /// Parent [RuleSet] if a nested rule otherwise [:null:].
+  /// Parent [RuleSet] if a nested rule otherwise `null`.
   RuleSet? _parentRuleSet;
 
   /// Top-most rule if nested rules.
@@ -253,7 +253,7 @@ class ExpandNestedSelectors extends Visitor {
   }
 
   /// Merge the nested selector sequences [current] to the [parent] sequences or
-  /// substitue any & with the parent selector.
+  /// substitute any & with the parent selector.
   List<SimpleSelectorSequence> _mergeNestedSelector(
       List<SimpleSelectorSequence> parent,
       List<SimpleSelectorSequence> current) {
@@ -270,7 +270,7 @@ class ExpandNestedSelectors extends Visitor {
     } else {
       for (var sequence in current) {
         if (sequence.simpleSelector.isThis) {
-          // Substitue the & with the parent selector and only use a combinator
+          // Substitute the & with the parent selector and only use a combinator
           // descendant if & is prefix by a sequence with an empty name e.g.,
           // "... + &", "&", "... ~ &", etc.
           var hasPrefix = newSequence.isNotEmpty &&

--- a/lib/src/css_printer.dart
+++ b/lib/src/css_printer.dart
@@ -32,7 +32,7 @@ class CssPrinter extends Visitor {
   String get _sp => prettyPrint ? ' ' : '';
 
   // TODO(terry): When adding obfuscation we'll need isOptimized (compact w/
-  //              obufuscation) and have isTesting (compact no obfuscation) and
+  //              obfuscation) and have isTesting (compact no obfuscation) and
   //              isCompact would be !prettyPrint.  We'll need another boolean
   //              flag for obfuscation.
   bool get _isTesting => !prettyPrint;

--- a/lib/src/messages.dart
+++ b/lib/src/messages.dart
@@ -68,7 +68,7 @@ class Message {
 /// This class tracks and prints information, warnings, and errors emitted by
 /// the compiler.
 class Messages {
-  /// Called on every error. Set to blank function to supress printing.
+  /// Called on every error. Set to blank function to suppress printing.
   final void Function(Message obj) printHandler;
 
   final PreprocessorOptions options;
@@ -110,7 +110,7 @@ class Messages {
     if (options.verbose) printHandler(msg);
   }
 
-  /// Merge [newMessages] to this message lsit.
+  /// Merge [newMessages] to this message list.
   void mergeMessages(Messages newMessages) {
     messages.addAll(newMessages.messages);
     newMessages.messages

--- a/lib/src/token_kind.dart
+++ b/lib/src/token_kind.dart
@@ -453,24 +453,25 @@ class TokenKind {
   //              see http://www.w3schools.com/cssref/pr_list-style-type.asp
   //              for list of possible values.
 
-  /// Check if name is a pre-defined CSS name.  Used by error handler to report
-  /// if name is unknown or used improperly.
+  /// Check if a name is a pre-defined CSS name.
+  ///
+  /// This is used by the error handler to report if a name is unknown or used
+  /// improperly.
   static bool isPredefinedName(String name) {
-    var nameLen = name.length;
-    // TODO(terry): Add more pre-defined names (hidden, bolder, inherit, etc.).
-    if (matchUnits(name, 0, nameLen) == -1 ||
-        matchDirectives(name, 0, nameLen) == -1 ||
-        matchMarginDirectives(name, 0, nameLen) == -1 ||
-        matchColorName(name) == null) {
-      return false;
-    }
+    final len = name.length;
 
-    return true;
+    // TODO(terry): Add more pre-defined names (hidden, bolder, inherit, etc.).
+    if (matchColorName(name) != null) return true;
+    if (matchDirectives(name, 0, len) != -1) return true;
+    if (matchMarginDirectives(name, 0, len) != -1) return true;
+    if (matchUnits(name, 0, len) != -1) return true;
+
+    return false;
   }
 
   /// Return the token that matches the unit ident found.
-  static int matchList(Iterable<Map<String, dynamic>> identList,
-      String tokenField, String text, int offset, int length) {
+  static int matchList(List<Map<String, dynamic>> identList, String tokenField,
+      String text, int offset, int length) {
     for (final entry in identList) {
       final ident = entry['value'] as String;
 
@@ -548,7 +549,7 @@ class TokenKind {
   }
 
   /// Match color name, case insensitive match and return the associated color
-  /// entry from _EXTENDED_COLOR_NAMES list, return [:null:] if not found.
+  /// entry from _EXTENDED_COLOR_NAMES list, return `null` if not found.
   static Map<String, Object>? matchColorName(String text) {
     var name = text.toLowerCase();
     for (var color in _EXTENDED_COLOR_NAMES) {

--- a/lib/src/validate.dart
+++ b/lib/src/validate.dart
@@ -85,7 +85,7 @@ class Validate {
           }
         } else if (simpleSelector is IdSelector) {
           // Any element id starting with an underscore is a private element id
-          // that doesn't have to match the world of known elemtn ids.
+          // that doesn't have to match the world of known element ids.
           if (!simpleSelector.name.startsWith('_')) {
             for (final id in ids) {
               if (simpleSelector.name == id) {

--- a/test/testing.dart
+++ b/test/testing.dart
@@ -57,13 +57,13 @@ final _cssVisitor = Visitor();
 
 /// Pretty printer for CSS.
 String prettyPrint(StyleSheet ss) {
-  // Walk the tree testing basic Vistor class.
+  // Walk the tree testing basic Visitor class.
   walkTree(ss);
   return (_emitCss..visitTree(ss, pretty: true)).toString();
 }
 
 /// Helper function to emit compact (non-pretty printed) CSS for suite test
-/// comparsions.  Spaces, new lines, etc. are reduced for easier comparsions of
+/// comparisons. Spaces, new lines, etc. are reduced for easier comparisons of
 /// expected suite test results.
 String compactOutput(StyleSheet ss) {
   walkTree(ss);


### PR DESCRIPTION
- update the logic in `isPredefinedName`
- address https://github.com/dart-lang/tools/issues/751
- update several unrelated typos

It did look like the logic in `isPredefinedName()` was suspect. It turns out that we only ever used this method for creating error messages for strings that we already knew weren't valid color names. Correcting the logic here won't actually affect our parsing logic (but will provide slightly more accurate error messages, and may be useful if this method is used for something else in the future).
