### PR TITLE
Add support for CSS `lh` and `rlh` units.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Adopted `package:dart_flutter_team_lints` linting rules.
 - Fixed the reported span for `Expression` nodes.
 - Fixed a regression parsing declaration values containing spaces.
+- Add support for `lh` and `rlh` units.
 
 ## 0.17.2
 

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -2470,6 +2470,11 @@ class _Parser {
         span = span.expand(_next().span);
         term = ViewportTerm(value, t!.text, span, unitType);
         break;
+      case TokenKind.UNIT_LH:
+      case TokenKind.UNIT_RLH:
+        span = span.expand(_next().span);
+        term = LineHeightTerm(value, t!.text, span, unitType);
+        break;
       default:
         if (value is Identifier) {
           term = LiteralTerm(value, value.name, span);

--- a/lib/src/css_printer.dart
+++ b/lib/src/css_printer.dart
@@ -548,6 +548,11 @@ class CssPrinter extends Visitor {
   }
 
   @override
+  void visitLineHeightTerm(LineHeightTerm node) {
+    emit(node.toString());
+  }
+
+  @override
   void visitFunctionTerm(FunctionTerm node) {
     // TODO(terry): Optimize rgb to a hexcolor.
     emit('${node.text}(');

--- a/lib/src/token_kind.dart
+++ b/lib/src/token_kind.dart
@@ -141,6 +141,8 @@ class TokenKind {
   static const int UNIT_VIEWPORT_VH = 624;
   static const int UNIT_VIEWPORT_VMIN = 625;
   static const int UNIT_VIEWPORT_VMAX = 626;
+  static const int UNIT_LH = 627; // Computed height of the element.
+  static const int UNIT_RLH = 628; // Line height of the root element.
 
   // Directives (@nnnn)
   static const int DIRECTIVE_NONE = 640;
@@ -289,6 +291,8 @@ class TokenKind {
     {'unit': TokenKind.UNIT_VIEWPORT_VH, 'value': 'vh'},
     {'unit': TokenKind.UNIT_VIEWPORT_VMIN, 'value': 'vmin'},
     {'unit': TokenKind.UNIT_VIEWPORT_VMAX, 'value': 'vmax'},
+    {'unit': TokenKind.UNIT_LH, 'value': 'lh'},
+    {'unit': TokenKind.UNIT_RLH, 'value': 'rlh'},
   ];
 
   // Some more constants:
@@ -711,6 +715,8 @@ class TokenKind {
       case TokenKind.UNIT_FREQ_HZ:
       case TokenKind.UNIT_FREQ_KHZ:
       case TokenKind.UNIT_FRACTION:
+      case TokenKind.UNIT_LH:
+      case TokenKind.UNIT_RLH:
         return true;
       default:
         return false;

--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -1409,6 +1409,18 @@ class RemTerm extends UnitTerm {
   dynamic visit(VisitorBase visitor) => visitor.visitRemTerm(this);
 }
 
+class LineHeightTerm extends UnitTerm {
+  LineHeightTerm(Object value, String text, SourceSpan? span,
+      [int unit = TokenKind.UNIT_LENGTH_PX])
+      : super(value, text, span, unit) {
+    assert(unit == TokenKind.UNIT_LH || unit == TokenKind.UNIT_RLH);
+  }
+  @override
+  LineHeightTerm clone() => LineHeightTerm(value, text, span, unit);
+  @override
+  dynamic visit(VisitorBase visitor) => visitor.visitLineHeightTerm(this);
+}
+
 class ViewportTerm extends UnitTerm {
   ViewportTerm(Object value, String text, SourceSpan? span,
       [int unit = TokenKind.UNIT_LENGTH_PX])

--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -1410,8 +1410,7 @@ class RemTerm extends UnitTerm {
 }
 
 class LineHeightTerm extends UnitTerm {
-  LineHeightTerm(Object value, String text, SourceSpan? span,
-      [int unit = TokenKind.UNIT_LENGTH_PX])
+  LineHeightTerm(Object value, String text, SourceSpan? span, int unit)
       : super(value, text, span, unit) {
     assert(unit == TokenKind.UNIT_LH || unit == TokenKind.UNIT_RLH);
   }

--- a/lib/visitor.dart
+++ b/lib/visitor.dart
@@ -86,6 +86,7 @@ abstract class VisitorBase {
   dynamic visitChTerm(ChTerm node);
   dynamic visitRemTerm(RemTerm node);
   dynamic visitViewportTerm(ViewportTerm node);
+  dynamic visitLineHeightTerm(LineHeightTerm node);
   dynamic visitFunctionTerm(FunctionTerm node);
   dynamic visitGroupTerm(GroupTerm node);
   dynamic visitItemTerm(ItemTerm node);
@@ -473,6 +474,11 @@ class Visitor implements VisitorBase {
 
   @override
   dynamic visitViewportTerm(ViewportTerm node) {
+    visitUnitTerm(node);
+  }
+
+  @override
+  dynamic visitLineHeightTerm(LineHeightTerm node) {
     visitUnitTerm(node);
   }
 

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -197,6 +197,8 @@ void testUnits() {
   padding-bottom: 3vmin;
   transform: rotate(20deg);
   voice-pitch: 10hz;
+  height: 4lh;
+  width: 40rlh;
 }
 #id-2 {
   left: 2fr;
@@ -235,6 +237,8 @@ void testUnits() {
   padding-bottom: 3vmin;
   transform: rotate(20deg);
   voice-pitch: 10hz;
+  height: 4lh;
+  width: 40rlh;
 }
 #id-2 {
   left: 2fr;


### PR DESCRIPTION
Adds support for line height computed units.

Supported only in [Chrome](https://caniuse.com/?search=lh%20unit) however it is part of the [W3 CSS spec].