### PR TITLE
Update processFont to handle null expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1-dev
+
+- Update `processFont` to handle null expressions.
+
 ## 1.0.0
 
 - Rev to `1.0.0` (note however that there are no API changes from `0.17.x`).

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -2852,9 +2852,9 @@ class ExpressionsProcessor {
     }
 
     return FontExpression(_exprs.span,
-        size: fontSize!.font.size,
-        lineHeight: fontSize.font.lineHeight,
-        family: fontFamily!.font.family);
+        size: fontSize?.font.size,
+        lineHeight: fontSize?.font.lineHeight,
+        family: fontFamily?.font.family);
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csslib
-version: 1.0.0
+version: 1.0.1-dev
 description: A library for parsing and analyzing CSS (Cascading Style Sheets).
 repository: https://github.com/dart-lang/csslib
 

--- a/test/declaration_test.dart
+++ b/test/declaration_test.dart
@@ -260,6 +260,33 @@ void testUnits() {
   expect(prettyPrint(stylesheet), generated);
 }
 
+void testNoValues() {
+  var errors = <Message>[];
+  final input = r'''
+.foo {
+  color: ;
+}
+.bar {
+  font:;
+  color: blue;
+}
+''';
+
+  final generated = r'''
+.foo {
+  color: ;
+}
+.bar {
+  font: ;
+  color: #00f;
+}''';
+
+  var stylesheet = parseCss(input, errors: errors, opts: simpleOptions);
+
+  expect(errors.isEmpty, true, reason: errors.toString());
+  expect(prettyPrint(stylesheet), generated);
+}
+
 void testUnicode() {
   var errors = <Message>[];
   final input = r'''
@@ -1435,6 +1462,7 @@ void main() {
   test('Identifiers', testIdentifiers);
   test('Composites', testComposites);
   test('Units', testUnits);
+  test('No Values', testNoValues);
   test('Unicode', testUnicode);
   test('Newer CSS', testNewerCss);
   test('Media Queries', testMediaQueries);


### PR DESCRIPTION
CSS
```css
.foo {
  color:;
}
.bar {
  font:;
  color: blue;
}
```
StackTrace:
```
Null check operator used on a null value
package:csslib/parser.dart 2855:23               ExpressionsProcessor.processFont
package:csslib/parser.dart 1912:43               _Parser.buildDartStyleNode
package:csslib/parser.dart 1884:14               _Parser._styleForDart
package:csslib/parser.dart 1762:27               _Parser.processDeclaration
package:csslib/parser.dart 1178:18               _Parser.processDeclarations
package:csslib/parser.dart 1095:37               _Parser.processRule
package:csslib/parser.dart 205:20                _Parser.parse
package:csslib/parser.dart 65:36                 compile
```